### PR TITLE
Change a bit in the debian folder

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Standards-Version: 3.9.6
 Build-Depends: debhelper (>=9)
 
 Package: nagios-plugin-check-scsi-smart
-Architecture: amd64
+Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Nagios SMART disk check over SCSI
  Tunnels ATA SMART commands over SCSI transports.  This allows ATA SMART checks

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
I tried to use this today as I stumbled over https://github.com/monitoring-plugins/monitoring-plugins/issues/1104.

It works. :smile: 

However, I had a few problems building:

* The architecture was fixed to `amd64`. I've changes this to `any` - `debuild` now uses the architecture of the host as the target to build for.
* This repository was not a native Debian package. This caused the build process to look for a upstream source. As this repository is already the upstream, I've changed this.